### PR TITLE
Remove name from User new registration and edit forms (Issue #12).

### DIFF
--- a/lib/generators/layout/devise/templates/registrations/edit.html.erb
+++ b/lib/generators/layout/devise/templates/registrations/edit.html.erb
@@ -3,10 +3,6 @@
   <%= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, :role => 'form'}) do |f| %>
     <%= devise_error_messages! %>
     <div class="form-group">
-      <%= f.label :name %>
-      <%= f.text_field :name, :autofocus => true, class: 'form-control' %>
-    </div>
-    <div class="form-group">
       <%= f.label :email %>
       <%= f.email_field :email, class: 'form-control' %>
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>

--- a/lib/generators/layout/devise/templates/registrations/new.html.erb
+++ b/lib/generators/layout/devise/templates/registrations/new.html.erb
@@ -3,10 +3,6 @@
     <h3>Sign up</h3>
     <%= devise_error_messages! %>
     <div class="form-group">
-      <%= f.label :name %>
-      <%= f.text_field :name, :autofocus => true, class: 'form-control' %>
-    </div>
-    <div class="form-group">
       <%= f.label :email %>
       <%= f.email_field :email, class: 'form-control' %>
     </div>


### PR DESCRIPTION
After thinking about it, I think just completely removing the name field is the true approach needed. Since name is a custom field, shouldn't it be up to the developer to add the field to the forms? The same with any other custom field they might add to the User model. That's my approach, your the maintainer of the gem so it's ultimately up to you but I think adding the field to the form in your Rails 4 Devise tutorial would also show the reader more about editing Devise and what can easily be done.
