### PR TITLE
Add .alert-dismissible to Bootstrap 3 flash messages

### DIFF
--- a/lib/generators/layout/install/templates/bootstrap3-messages.html.erb
+++ b/lib/generators/layout/install/templates/bootstrap3-messages.html.erb
@@ -1,7 +1,7 @@
 <%# Rails flash messages styled for Bootstrap 3.0 %>
 <% flash.each do |name, msg| %>
   <% if msg.is_a?(String) %>
-    <div class="alert alert-<%= name.to_s == 'notice' ? 'success' : 'danger' %>">
+    <div class="alert alert-dismissible alert-<%= name.to_s == 'notice' ? 'success' : 'danger' %>">
       <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
       <%= content_tag :div, msg, :id => "flash_#{name}" %>
     </div>

--- a/lib/generators/layout/install/templates/bootstrap3-messages.html.haml
+++ b/lib/generators/layout/install/templates/bootstrap3-messages.html.haml
@@ -1,6 +1,6 @@
 -# Rails flash messages styled for Bootstrap 3.0
 - flash.each do |name, msg|
   - if msg.is_a?(String)
-    %div{:class => "alert alert-#{name.to_s == 'notice' ? 'success' : 'danger'}"}
+    %div{:class => "alert alert-dismissible alert-#{name.to_s == 'notice' ? 'success' : 'danger'}"}
       %button.close{"aria-hidden" => "true", "data-dismiss" => "alert", :type => "button"} &times;
       = content_tag :div, msg, :id => "flash_#{name}"

--- a/lib/generators/layout/install/templates/bootstrap3-messages.html.slim
+++ b/lib/generators/layout/install/templates/bootstrap3-messages.html.slim
@@ -1,6 +1,6 @@
 / Rails flash messages styled for Bootstrap 3.0
 - flash.each do |name, msg|
   - if msg.is_a?(String)
-    div class="alert alert-#{name.to_s == 'notice' ? 'success' : 'danger'}"
+    div class="alert alert-dismissible alert-#{name.to_s == 'notice' ? 'success' : 'danger'}"
       button.close[type="button" data-dismiss="alert" aria-hidden="true"] ×
       = content_tag :div, msg, :id => "flash_#{name}"


### PR DESCRIPTION
The .alert-dismissible class adds some extra styling to the alert div, most importantly vertically centering the .close class in the alert div.