### PR TITLE
[bootstrap4] Rename `.text-xs-*` to `.text-*`

### DIFF
--- a/lib/generators/layout/install/templates/bootstrap4_and_overrides.css.scss
+++ b/lib/generators/layout/install/templates/bootstrap4_and_overrides.css.scss
@@ -17,14 +17,14 @@ img {
 // to make views framework-neutral
 .column {
   @extend .col-md-6;
-  @extend .text-xs-center;
+  @extend .text-center;
 }
 .form {
   @extend .col-md-6;
 }
 .form-centered {
   @extend .col-md-6;
-  @extend .text-xs-center;
+  @extend .text-center;
 }
 .submit {
   @extend .btn;


### PR DESCRIPTION
Rename `.text-xs-*` to `.text-*` for use bootstrap v4.0.0-alpha.6

docs: https://github.com/twbs/bootstrap/pull/21217